### PR TITLE
Week 3: WhatsApp share + empty state

### DIFF
--- a/src/components/EmptyState.jsx
+++ b/src/components/EmptyState.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Music } from 'lucide-react';
+
+const EmptyState = ({ title, subtitle, actionLabel, onAction }) => {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-900 via-purple-900 to-pink-900 p-4 py-8">
+      <div className="max-w-3xl mx-auto">
+        <div className="bg-white/10 backdrop-blur-xl rounded-3xl p-12 border border-white/20 text-center">
+          <div className="mx-auto mb-6 w-20 h-20 rounded-2xl bg-gradient-to-br from-pink-500 to-purple-500 flex items-center justify-center">
+            <Music className="w-10 h-10 text-white" />
+          </div>
+
+          <h2 className="text-4xl font-bold text-white mb-3">{title}</h2>
+          {subtitle && <p className="text-white/70 text-lg mb-8">{subtitle}</p>}
+
+          {actionLabel && onAction && (
+            <button
+              onClick={onAction}
+              className="inline-flex items-center justify-center bg-white/15 hover:bg-white/25 text-white px-8 py-4 rounded-xl transition-colors text-lg font-semibold"
+            >
+              {actionLabel}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/src/components/PlaylistView.jsx
+++ b/src/components/PlaylistView.jsx
@@ -22,6 +22,8 @@ import {
 } from 'lucide-react';
 import { StorageService } from '../utils/storage';
 import { MusicDbService } from '../services/musicDbService'; // IMPORTED NEW SERVICE
+import EmptyState from './EmptyState';
+import { buildWhatsAppShareUrl } from '../utils/whatsappShare';
 // Removed unused Spotify imports to avoid confusion/errors
 // import { getPopularTracksForCountry, getRecommendations } from '../services/spotifyService';
 
@@ -322,8 +324,30 @@ console.log("typeof isLiked:", typeof isLiked);
       return `${m}:${s < 10 ? '0' : ''}${s}`;
    };
 
+   const handleShareOnWhatsApp = () => {
+      const spotifyUrl = currentTrack?.spotifyUrl || suggestedTracks.find((t) => t?.spotifyUrl)?.spotifyUrl;
+      const playlistTitle = userData?.firstName ? `${userData.firstName}'s Playlist` : 'P-Play Playlist';
+
+      const url = buildWhatsAppShareUrl({
+         playlistTitle,
+         tracks: suggestedTracks,
+         spotifyUrl
+      });
+
+      window.open(url, '_blank', 'noopener,noreferrer');
+   };
+
    // --- RENDER HELPERS ---
-   if (!playlist) return <div className="text-white p-10">Loading...</div>;
+   if (!playlist || !playlist?.tracks || playlist.tracks.length === 0) {
+      return (
+         <EmptyState
+            title="Empty Library"
+            subtitle="No playlists yet. Create one to start listening."
+            actionLabel="Create Playlist"
+            onAction={onCreateNew}
+         />
+      );
+   }
 
    const genreNames = {
       1: 'Pop', 2: 'Rock', 3: 'Hip Hop', 4: 'Rap', 5: 'Electronic',
@@ -402,6 +426,13 @@ console.log("typeof isLiked:", typeof isLiked);
                                     <ExternalLink className="w-3 h-3" /> Listen on Spotify
                                  </a>
                               )}
+
+                              <button
+                                 onClick={handleShareOnWhatsApp}
+                                 className="mt-2 inline-flex items-center gap-2 text-xs bg-green-500/20 hover:bg-green-500/30 text-green-200 px-3 py-1.5 rounded-full transition-colors"
+                              >
+                                 Share On WhatsApp
+                              </button>
                            </div>
                            <button
                               onClick={() => toggleLikedSong(currentTrack)}

--- a/src/utils/whatsappShare.js
+++ b/src/utils/whatsappShare.js
@@ -1,0 +1,28 @@
+export function buildWhatsAppShareUrl({ playlistTitle, tracks = [], spotifyUrl }) {
+  const title = (playlistTitle || 'P-Play Playlist').trim();
+
+  const lines = [];
+  lines.push(`🎧 ${title}`);
+  lines.push('');
+
+  if (Array.isArray(tracks) && tracks.length > 0) {
+    lines.push('🎵 Tracklist:');
+    tracks.slice(0, 10).forEach((t, i) => {
+      const trackTitle = t?.title || t?.name || 'Unknown title';
+      const artist = t?.artist || t?.artistName || t?.artists?.[0]?.name || '';
+      lines.push(`${i + 1}. ${trackTitle}${artist ? ' — ' + artist : ''}`);
+    });
+    if (tracks.length > 10) lines.push(`… +${tracks.length - 10} more`);
+    lines.push('');
+  }
+
+  if (spotifyUrl) {
+    lines.push(`Listen on Spotify: ${spotifyUrl}`);
+    lines.push('');
+  }
+
+  lines.push('Generated via P-Play');
+
+  const text = lines.join('\n');
+  return `https://wa.me/?text=${encodeURIComponent(text)}`;
+}


### PR DESCRIPTION
Implemented Week 3 tasks:
- Task 14: Added "Share On WhatsApp" button that generates a formatted message with tracklist + Spotify link.
- Task 15: Added Empty State screen when the library has no playlists, including a "Create Playlist" CTA.

Tested locally: Share opens WhatsApp Web with pre-filled message; Empty Library shows CTA and navigates to create flow.
